### PR TITLE
Feature/beat box speed voice

### DIFF
--- a/lib/beat_box.rb
+++ b/lib/beat_box.rb
@@ -1,5 +1,6 @@
 class BeatBox
   attr_reader :list
+  attr_accessor :voice, :rate
   def initialize(first_beats)
     @rate = 500
     @voice = 'Cellos'

--- a/lib/beat_box.rb
+++ b/lib/beat_box.rb
@@ -55,4 +55,12 @@ class BeatBox
   def play
     `say -r #{@rate} -v #{@voice} #{all}`
   end
+
+  def reset_voice
+    @voice = 'Cellos'
+  end
+
+  def reset_rate
+    @rate = 500
+  end
 end

--- a/lib/beat_box.rb
+++ b/lib/beat_box.rb
@@ -1,8 +1,20 @@
 class BeatBox
   attr_reader :list
-  def initialize
-    @list = LinkedList.new
+  def initialize(first_beats)
     @beats_dictionary = 'tee dee deep bop boop la na boo witt bonk rit goop sit'
+    @list = LinkedList.new
+    # Was not able to call the append method from outside initialize method
+    if first_beats == ''
+      @list
+    else
+      beats_dictionary_separated = @beats_dictionary.split(' ')
+      first_beats_separated = first_beats.split(' ')
+      valid_beats = first_beats_separated.select do |node_data|
+        beats_dictionary_separated.include?(node_data)
+      end
+      valid_beats.each { |valid_beat| @list.append(valid_beat) }
+    end
+##
   end
 
   def append(more_data)

--- a/lib/beat_box.rb
+++ b/lib/beat_box.rb
@@ -1,9 +1,12 @@
 class BeatBox
   attr_reader :list
   def initialize(first_beats)
+    @rate = 500
+    @voice = 'Cellos'
     @beats_dictionary = 'tee dee deep bop boop la na boo witt bonk rit goop sit'
     @list = LinkedList.new
     # Was not able to call the append method from outside initialize method
+    # Probably not best, but directly coded it in the initialize method
     if first_beats == ''
       @list
     else
@@ -14,7 +17,6 @@ class BeatBox
       end
       valid_beats.each { |valid_beat| @list.append(valid_beat) }
     end
-##
   end
 
   def append(more_data)
@@ -50,6 +52,6 @@ class BeatBox
   end
 
   def play
-    `say -r 500 -v Cellos #{all}`
+    `say -r #{@rate} -v #{@voice} #{all}`
   end
 end

--- a/spec/beat_box_spec.rb
+++ b/spec/beat_box_spec.rb
@@ -4,7 +4,7 @@ require './lib/node'
 
 RSpec.describe LinkedList do
   before(:each) do
-    @bb = BeatBox.new
+    @bb = BeatBox.new('')
   end
 
   describe '#initialize' do
@@ -18,6 +18,11 @@ RSpec.describe LinkedList do
 
     it 'has head' do
       expect(@bb.list.head).to be_nil
+    end
+
+    it 'can append multiple nodes with argument' do
+      bb_2 = BeatBox.new('dee dee denver bop')
+      expect(bb_2.all).to eq('dee dee bop')
     end
   end
 
@@ -73,5 +78,9 @@ RSpec.describe LinkedList do
       # Plays TWO sounds that are the same
       expect(@bb.play).to eq(`say -r 500 -v Cellos 'deep boo witt bonk sit goop'`)
     end
+  end
+
+  describe '#voice' do
+    
   end
 end

--- a/spec/beat_box_spec.rb
+++ b/spec/beat_box_spec.rb
@@ -31,17 +31,17 @@ RSpec.describe LinkedList do
     end
 
     it 'play default voice and play a different input voice' do
-      @bb.append('boop boop boop boop boop')
-      expect(@bb.play).to eq(`say -r 500 -v Cellos 'boop boop boop boop boop'`)
+      @bb.append('boop boop boop')
+      expect(@bb.play).to eq(`say -r 500 -v Cellos 'boop boop boop'`)
       @bb.voice = 'Daniel'
-      expect(@bb.play).to eq(`say -r 500 -v Daniel 'boop boop boop boop boop'`)
+      expect(@bb.play).to eq(`say -r 500 -v Daniel 'boop boop boop'`)
     end
 
     it 'play at default rate and play at different input rate' do
-      @bb.append('tee tee tee tee tee')
-      expect(@bb.play).to eq(`say -r 500 -v Cellos 'tee tee tee tee tee'`)
+      @bb.append('tee tee tee')
+      expect(@bb.play).to eq(`say -r 500 -v Cellos 'tee tee tee'`)
       @bb.rate = 100
-      expect(@bb.play).to eq(`say -r 100 -v Cellos 'tee tee tee tee tee'`)
+      expect(@bb.play).to eq(`say -r 100 -v Cellos 'tee tee tee'`)
     end
 
   end
@@ -100,8 +100,23 @@ RSpec.describe LinkedList do
     end
   end
 
-  describe '#voice' do
-
+  describe '#reset_voice' do
+    it 'will reset to default Cellos after it was changed' do
+      @bb.append('witt witt witt')
+      @bb.voice = 'Daniel'
+      expect(@bb.play).to eq(`say -r 500 -v Daniel 'witt witt witt'`)
+      @bb.reset_voice
+      expect(@bb.play).to eq(`say -r 500 -v Cellos 'witt witt witt'`)
+    end
   end
 
+  describe '#reset_rate' do
+    it 'will reset to default rate after it was changed' do
+      @bb.append('la la la')
+      @bb.rate = 100
+      expect(@bb.play).to eq(`say -r 100 -v Cellos 'la la la'`)
+      @bb.reset_rate
+      expect(@bb.play).to eq(`say -r 500 -v Cellos 'la la la'`)
+    end
+  end
 end

--- a/spec/beat_box_spec.rb
+++ b/spec/beat_box_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe LinkedList do
       bb_2 = BeatBox.new('dee dee denver bop')
       expect(bb_2.all).to eq('dee dee bop')
     end
+
+    it 'has default rate' do
+      @bb.append('tee tee tee deep bop')
+
+    end
+
+    it 'has default voice and rate' do
+      @bb.append('tee tee tee')
+      expect(@bb.play).to eq(`say -r 500 -v Cellos 'tee tee tee'`)
+    end
   end
 
   describe '#append' do

--- a/spec/beat_box_spec.rb
+++ b/spec/beat_box_spec.rb
@@ -30,10 +30,20 @@ RSpec.describe LinkedList do
 
     end
 
-    it 'has default voice and rate' do
-      @bb.append('tee tee tee')
-      expect(@bb.play).to eq(`say -r 500 -v Cellos 'tee tee tee'`)
+    it 'play default voice and play a different input voice' do
+      @bb.append('boop boop boop boop boop')
+      expect(@bb.play).to eq(`say -r 500 -v Cellos 'boop boop boop boop boop'`)
+      @bb.voice = 'Daniel'
+      expect(@bb.play).to eq(`say -r 500 -v Daniel 'boop boop boop boop boop'`)
     end
+
+    it 'play at default rate and play at different input rate' do
+      @bb.append('tee tee tee tee tee')
+      expect(@bb.play).to eq(`say -r 500 -v Cellos 'tee tee tee tee tee'`)
+      @bb.rate = 100
+      expect(@bb.play).to eq(`say -r 100 -v Cellos 'tee tee tee tee tee'`)
+    end
+
   end
 
   describe '#append' do
@@ -91,6 +101,7 @@ RSpec.describe LinkedList do
   end
 
   describe '#voice' do
-    
+
   end
+
 end


### PR DESCRIPTION
Added three features. Add beat data directly when initializing and creating a new BeatBox object instance. Default sound voice/rate and methods to reset back to default.